### PR TITLE
Remove coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ scala:
 
 script: "sbt ++$TRAVIS_SCALA_VERSION coverage test"
 after_success:
-   - "sbt ++$TRAVIS_SCALA_VERSION coverageReport coveralls"
    - "bash <(curl -s https://codecov.io/bash)"
    - "sbt coverageReport codacyCoverage"
    - "sbt ++$TRAVIS_SCALA_VERSION versioneye:updateProject"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # free-event-sourcing
 [![Build Status](https://travis-ci.org/msiegenthaler/free-event-sourcing.svg?branch=master)](https://travis-ci.org/msiegenthaler/free-event-sourcing)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f27964cb900d4e55940ef7eecfb1a48f)](https://www.codacy.com/app/msiegenthaler/free-event-sourcing?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=msiegenthaler/free-event-sourcing&amp;utm_campaign=Badge_Grade)
-[![Coverage Status](https://coveralls.io/repos/github/msiegenthaler/free-event-sourcing/badge.svg?branch=master)](https://coveralls.io/github/msiegenthaler/free-event-sourcing?branch=master)
-[![codecov](https://codecov.io/gh/msiegenthaler/free-event-sourcing/branch/master/graph/badge.svg)](https://codecov.io/gh/msiegenthaler/free-event-sourcing)
+[![Codecov](https://codecov.io/gh/msiegenthaler/free-event-sourcing/branch/master/graph/badge.svg)](https://codecov.io/gh/msiegenthaler/free-event-sourcing)
 [![VersionEye](https://www.versioneye.com/user/projects/5735bd58ebad9c000ef76535/badge.svg)](https://www.versioneye.com/user/projects/5735bd58ebad9c000ef76535)
 
 Purely functional Event Sourcing based on Domain Driven Design and implemented using Free Monads.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,6 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M11")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-
 addSbtPlugin("com.versioneye" % "sbt-versioneye-plugin" % "0.2.0")
 
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.3.0")


### PR DESCRIPTION
We don't need to coverage reporting tools. Was broken with java 8 anyway.